### PR TITLE
Add `do-not-auto-tag` flag CLI option

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -40,6 +40,8 @@ jobs:
     - name: Test with pytest
       env: # Set the secret as an environment variable
         REAI_API_KEY: ${{ secrets.REAI_API_KEY }}
+        REAI_API_HOST: ${{ secrets.REAI_API_HOST }}
+        HEADER_HOST: "api.local"
       run: |
         pip install pytest
         python -m pytest tests/

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -41,7 +41,6 @@ jobs:
       env: # Set the secret as an environment variable
         REAI_API_KEY: ${{ secrets.REAI_API_KEY }}
         REAI_API_HOST: ${{ secrets.REAI_API_HOST }}
-        HEADER_HOST: "api.local"
       run: |
         pip install pytest
         python -m pytest tests/

--- a/src/reait/api.py
+++ b/src/reait/api.py
@@ -166,7 +166,8 @@ def RE_delete(fpath: str, binary_id: int = 0) -> Response:
 def RE_analyse(fpath: str, model_name: str = None, isa_options: str = None,
                platform_options: str = None, file_options: str = None, dynamic_execution: bool = False,
                command_line_args: str = None, binary_scope: str = None, tags: list = None, priority: int = 0,
-               duplicate: bool = False, symbols: dict = None, debug_fpath: str = None) -> Response:
+               duplicate: bool = False, symbols: dict = None, debug_fpath: str = None,
+               skip_scraping: bool = False) -> Response:
     """
     Start analysis job for binary file
     :param fpath: File path for binary to analyse
@@ -182,6 +183,7 @@ def RE_analyse(fpath: str, model_name: str = None, isa_options: str = None,
     :param duplicate: Duplicate an existing binary
     :param symbols: JSON object containing the base address and the list of functions
     :param debug_fpath: File path for debug file
+    :param skip_scraping: Disable/Enable auto-tagging of binary sample in relevant APIs
     """
     bin_id = re_binary_id(fpath)
     result = re_hash_check(bin_id)
@@ -207,7 +209,8 @@ def RE_analyse(fpath: str, model_name: str = None, isa_options: str = None,
             pass
     
     for p_name in ("model_name", "isa_options", "platform_options", "file_options",
-                   "dynamic_execution", "command_line_args", "binary_scope", "tags", "priority", "symbols",):
+                   "dynamic_execution", "command_line_args", "binary_scope",
+                   "tags", "priority", "symbols", "skip_scraping"):
         p_value = locals()[p_name]
 
         if p_value:

--- a/src/reait/main.py
+++ b/src/reait/main.py
@@ -17,7 +17,7 @@ from scipy.spatial import distance
 from glob import iglob
 import numpy as np
 
-import api
+from . import api
 
 rerr = Console(file=stderr, width=180)
 rout = Console(file=stdout, width=180)
@@ -210,7 +210,7 @@ def main() -> int:
                         help="Override analysis visibility (scope). Valid values are 'public' or 'private'[DEFAULT]")
     parser.add_argument("--tags", default=None, type=str,
                         help="Assign tags to an analysis. Valid responses are tag1,tag2,tag3.")
-    parser.add_argument("--do-not-auto-tag", default=False, type=bool, action="store_true",help="Disable auto-tagging in API views",)
+    parser.add_argument("--do-not-auto-tag", default=False, action="store_true" ,help="Disable auto-tagging in API views",)
     parser.add_argument("--priority", default=0, type=int, help="Add priority to processing queue.")
     parser.add_argument("--verbose", default=False, action="store_true", help="Set verbose output.")
     parser.add_argument("--debug", default=None, help="Debug file path to write pass with analysis")

--- a/src/reait/main.py
+++ b/src/reait/main.py
@@ -210,6 +210,7 @@ def main() -> int:
                         help="Override analysis visibility (scope). Valid values are 'public' or 'private'[DEFAULT]")
     parser.add_argument("--tags", default=None, type=str,
                         help="Assign tags to an analysis. Valid responses are tag1,tag2,tag3.")
+    parser.add_argument("--do-not-auto-tag", default=False, type=bool, action="store_true",help="Disable auto-tagging in API views",)
     parser.add_argument("--priority", default=0, type=int, help="Add priority to processing queue.")
     parser.add_argument("--verbose", default=False, action="store_true", help="Set verbose output.")
     parser.add_argument("--debug", default=None, help="Debug file path to write pass with analysis")
@@ -266,7 +267,9 @@ def main() -> int:
                                platform_options=args.platform, dynamic_execution=args.dynamic_execution,
                                command_line_args=args.cmd_line_args, file_options=args.exec_format,
                                binary_scope=args.scope.upper(), tags=tags, priority=args.priority,
-                               duplicate=args.duplicate, debug_fpath=args.debug)
+                               duplicate=args.duplicate, debug_fpath=args.debug,
+                               skip_scraping=args.do_not_auto_tag
+                               )
 
             if args.delete:
                 try:
@@ -306,7 +309,9 @@ def main() -> int:
                            platform_options=args.platform, dynamic_execution=args.dynamic_execution,
                            command_line_args=args.cmd_line_args, file_options=args.exec_format,
                            binary_scope=args.scope.upper(), tags=tags, priority=args.priority,
-                           duplicate=args.duplicate, debug_fpath=args.debug)
+                           duplicate=args.duplicate, debug_fpath=args.debug,
+                           skip_scraping=args.do_not_auto_tag
+                           )
 
         elif args.extract:
             embeddings = api.RE_embeddings(args.binary).json()

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -46,10 +46,9 @@ class BaseTestCase(TestCase):
         testlog.info("Random selection of '%s' in binaries folder", cls._fpath)
 
         api.re_conf["model"] = f"{cls.MODEL_NAME_PREFIX}{cls._platform}"
-
         # Get the API key from the environment variable
         api.re_conf["apikey"] = getenv("REAI_API_KEY", api.re_conf["apikey"])
-
+        api.re_conf["header-host"] = getenv("HEADER_HOST", 'api.local')
 
         # Deletes all previous analyses from the RevEng.AI platform
         cls._cleanup_binaries(cls._fpath)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -28,9 +28,11 @@ testlog.addHandler(logging.StreamHandler(stdout))
 class BaseTestCase(TestCase):
     __metaclass__ = abc.ABCMeta
 
+    MODEL_NAME_PREFIX = "binnet-0.4-x86-"
     _cwd: str = None
     _fpath: str = None
     _platform: str = None
+
 
     @classmethod
     def setUpClass(cls):
@@ -43,10 +45,11 @@ class BaseTestCase(TestCase):
 
         testlog.info("Random selection of '%s' in binaries folder", cls._fpath)
 
-        api.re_conf["model"] = "binnet-0.3-x86-" + cls._platform
+        api.re_conf["model"] = f"{cls.MODEL_NAME_PREFIX}{cls._platform}"
 
         # Get the API key from the environment variable
         api.re_conf["apikey"] = getenv("REAI_API_KEY", api.re_conf["apikey"])
+
 
         # Deletes all previous analyses from the RevEng.AI platform
         cls._cleanup_binaries(cls._fpath)
@@ -58,7 +61,12 @@ class BaseTestCase(TestCase):
 
             testlog.info("Getting all previous analyses for %s", bin_id)
 
-            response = api.reveng_req(get, "v1/search", json_data={"sha_256_hash": bin_id}).json()
+            response = api.reveng_req(
+                get,
+                "v1/search",
+                json_data={"sha_256_hash": bin_id},
+                ex_headers={"Host": "api.local"}
+            ).json()
 
             if not response["success"]:
                 testlog.error("Failed to get all previous analysis.\n%s", response)


### PR DESCRIPTION
This PR contains the addition of a `--do-not-auto-tag` flag to the CLI, which allows control over the skip_scraping option for APIs.


Note: CLI test requests hit dev API now but to resolve CI pipeline issues, API credentials needs to be updated in github actions. 

EXAMPLE USAGE:

```
reait -b /usr/bin/true -a --model=binnet-0.4-x86-windows --binary=windows/argv.exe --apikey=<API_KEY> --analyse --duplicate --do-not-auto-tag
```


